### PR TITLE
fix 'Unresolved externals' error at link

### DIFF
--- a/SRC/CORE.ASM
+++ b/SRC/CORE.ASM
@@ -19,7 +19,7 @@
 	extrn	w_back		:word
 	endws
 
-	extrn	chkdosheight	:near
+;	extrn	chkdosheight	:near
 	extrn	chkline1	:near
 	extrn	clrbtm		:near
 	extrn	cls		:near

--- a/SRC/DOS.ASM
+++ b/SRC/DOS.ASM
@@ -64,7 +64,7 @@ _pblk		ends
 	extrn	stopintnum	:word
 	extrn	stops		:word
 	extrn	syssw		:word
-	extrn	texts		:word
+;	extrn	texts		:word
 	extrn	tmpbuf		:word
 ;	extrn	tmpbuf2		:word
 	extrn	parbuf		:near	; ##156.96
@@ -90,7 +90,7 @@ _pblk		ends
 	extrn	xmem_close	:near
 	extrn	xmem_extend	:near
 	extrn	tmp_close	:near
-	extrn	ems_free	:near
+;	extrn	ems_free	:near
 	extrn	ems_resetmap	:near
 	extrn	ems_restore	:near
 	extrn	ems_save	:near

--- a/SRC/MACRO.ASM
+++ b/SRC/MACRO.ASM
@@ -128,7 +128,7 @@ _mget		ends
 	extrn	scantbl		:near
 	extrn	dispmsg		:near
 	extrn	scan_flcmd	:near
-	extrn	flsyscall	:near
+;	extrn	flsyscall	:near
 	extrn	load_iniopt	:near
 	extrn	reset_histp	:near
 	extrn	open_ext	:near

--- a/SRC/MAIN.ASM
+++ b/SRC/MAIN.ASM
@@ -140,7 +140,7 @@ refp	macro	label
 	extrn	write_logtbl	:near
 	extrn	set_insm	:near
 	extrn	init_maclink	:near
-	extrn	init_module	:near
+;	extrn	init_module	:near
 	extrn	set_opnopt	:near
 	extrn	set_blktgt	:near
 	extrn	check_vwx	:near

--- a/SRC/SCRN.ASM
+++ b/SRC/SCRN.ASM
@@ -7,7 +7,7 @@
 ;--- External symbols ---
 
 	wseg
-	extrn	altsize		:byte
+;	extrn	altsize		:byte
 	extrn	atrtbl		:byte
 	extrn	atrucsr		:byte
 	extrn	atrflag		:byte
@@ -48,7 +48,9 @@ ENDIF
 	extrn	optputs		:near
 	extrn	toupper		:near
 	extrn	resetfp		:near
+IFDEF PC98
 	extrn	sm_sensekey	:near
+ENDIF
 
 	dseg
 

--- a/SRC/TEXT.ASM
+++ b/SRC/TEXT.ASM
@@ -42,7 +42,7 @@ ENDIF
 	extrn	rends		:word
 	extrn	syssw		:word
 	extrn	tbsize		:word
-	extrn	tmpnamep	:word
+;	extrn	tmpnamep	:word
 	extrn	w_busy		:word
 	extrn	w_free		:word
 	extrn	tmpslot		:word
@@ -70,7 +70,7 @@ ENDIF
 	extrn	initblk		:near
 	extrn	isviewmode	:near
 	extrn	jumpnum		:near
-	extrn	killmemtmp	:near
+;	extrn	killmemtmp	:near
 	extrn	ld_wact		:near
 	extrn	makefulpath	:near
 	extrn	maptext		:near
@@ -79,7 +79,7 @@ ENDIF
 	extrn	ofs2seg		:near
 	extrn	parsepath	:near
 	extrn	ptradj		:near
-	extrn	readmemtmp	:near
+;	extrn	readmemtmp	:near
 	extrn	restcp		:near
 	extrn	scannum		:near
 	extrn	searchfile	:near
@@ -109,7 +109,7 @@ ENDIF
 	extrn	wndsel		:near
 	extrn	wrdcpy		:near
 	extrn	wrdicmp		:near
-	extrn	writememtmp	:near
+;	extrn	writememtmp	:near
 	extrn	xmem_alloc	:near
 	extrn	xmem_free	:near
 	extrn	xmem_read	:near


### PR DESCRIPTION
MS-DOSエミュレータ[emu2](https://github.com/dmsc/emu2)と[MicrosoftのMS-DOS公式リポジトリ](https://github.com/microsoft/MS-DOS/tree/main)にあるMS-DOS4.0付属のMASM.EXE, LINK.EXE, EXE2BIN.EXEを使用し、VZエディタのビルドを試みています。 その際に見つけた、リンク時に
```
LINK : error L2029: Unresolved externals:



killmemtmp in file(s):
 TEXT.OBJ(text.asm)
tmpnamep in file(s):
 TEXT.OBJ(text.asm)
writememtmp in file(s):
 TEXT.OBJ(text.asm)
readmemtmp in file(s):
 TEXT.OBJ(text.asm)

There were 4 errors detected
gmake: *** [GNUmakefile:85: vzus.exe] エラー 2
```
といった未解決シンボルによるエラーが発生しています（実際はもっと多いです）。
未解決シンボルといっても実際は未使用であるために実害は無いようですが、[GNUmakefile](https://github.com/jg1uaa/VZEditor/blob/emu2/SRC/GNUmakefile)を作成してPC-UNIX上でビルドする際においては作業の支障となるため、修正を試みました。

プロジェクトの運営方針…当時のソースコードを一切手を加えずに保存することを目的としているのか、いくらかの手を加え今の時代においても活用できるようにしていくのかはこちらでは分からないのですが、どなたかの役に立つことを願いpull-requestを出しておきます。